### PR TITLE
ReadMe cleanup 2

### DIFF
--- a/README-DE.md
+++ b/README-DE.md
@@ -10,20 +10,23 @@ Mit diesem Addon wird es dir dank [Advanced Launcher](http://forum.kodi.tv/showt
 
 ## Installationsanleitung
 - Lade die [neuste Version](https://github.com/bite-your-idols/Gamestarter-Pi/releases/latest) herunter und kopiere sie auf deinen **Raspberry Pi**
-- Öffne **Kodi → Einstellungen → System → Addons** und aktiviere **Unbekannte Quellen**
+- **[Kodi 17+]** Öffne **Kodi → Einstellungen → System → Addons** und aktiviere **Unbekannte Quellen**
 - Öffne **Kodi → Addons → Aus ZIP-Datei installieren** und wähle deine heruntergeladene `.zip`-Datei
 
 Wenn das Addon zum ersten Mal gestartet wird, erfolgt eine Erstkonfiguration. Danach kannst du deine [ROMs](https://github.com/libretro/Lakka/wiki/ROMs) und [BIOSes](https://github.com/libretro/Lakka/wiki/BIOSes) über [Samba](https://wiki.libreelec.tv/index.php?title=Accessing_LibreELEC#tab=Samba_2FSMB) nach `/storage/emulators/` kopieren.
+
+> Seit **Kodi 17** musst du **Advanced Emulator Launcher** manuell aktivieren:
+<br>Öffne **Addons → Benutzer-Addons → Programm-Addons → Advanced Emulator Laucher** und klicke auf **Aktivieren**
 
 ## Zusätzliche Programme
 Du kannst die Addon Einstellungen aufrufen um zusätzliche Funktionen zu installieren.
 - **[EmulationStation](http://emulationstation.org/):** ein schöne Benutzeroberfläche, auch benutzt von [RetroPie](https://retropie.org.uk/) und [Recalbox](https://recalbox.com/), und zusätzliche Designs
 - **[Internet Archive ROM Launcher](https://github.com/zach-morris/plugin.program.iarl/wiki):** ein Addon um Spiele vom [Internet Archive](https://archive.org/) zu starten (siehe [#31](https://github.com/bite-your-idols/Gamestarter-Pi/issues/31))
-- **Experimentelle RetroArch Emulatoren:** [lr-desmume](https://github.com/libretro/desmume), [lr-mame2010](https://github.com/libretro/mame2010-libretro), [lr-yabause](https://github.com/libretro/yabause)
+- **Experimentelle RetroArch Emulatoren:** [lr-desmume](https://github.com/libretro/desmume), [lr-mame2010](https://github.com/libretro/mame2010-libretro), [lr-yabause](https://github.com/libretro/yabause) ...
 - **[uae4arm-rpi](https://github.com/Chips-fr/uae4arm-rpi):** Amiga Emulator (siehe [#34](https://github.com/bite-your-idols/Gamestarter-Pi/issues/34))
+- **[DraStic](https://www.raspberrypi.org/forums/viewtopic.php?t=170820&p=1104991):** Experimenteller Nintendo DS Emulator
 - **[Libretro PC Portierungen](https://buildbot.libretro.com/assets/cores/):** Cave Story, Doom, Quake, Dinothawr
-
-Du kannst [diesen](https://github.com/bite-your-idols/Gamestarter-Pi/raw/master/packages/skin.estuary.zip) **modifizieren Estuary Skin** herunterladen, um einen **Games** Menüpunkt im Hauptmenü zu erhalten (siehe [#48](https://github.com/bite-your-idols/Gamestarter-Pi/issues/48)).
+- **Angepasster Estuary Skin:** Fügt einen Menüpunkt für Gamestarter oder Advanced Emulator Launcher im Hauptmenü hinzu (siehe [#48](https://github.com/bite-your-idols/Gamestarter-Pi/issues/48))
 
 ## Unterstützte Systeme
 ### Beliebte Systeme
@@ -55,14 +58,15 @@ Du kannst [diesen](https://github.com/bite-your-idols/Gamestarter-Pi/raw/master/
 - Sega Game Gear ([lr-genesis-plus-gx](https://github.com/libretro/Genesis-Plus-GX))
 - ScummVM ([lr-scummvm](https://github.com/libretro/scummvm))
 - Vectrex ([lr-vecx](https://github.com/libretro/libretro-vecx))
-- WondeSwan / WonderSwan Color ([lr-mednafen-wswan](https://github.com/libretro/beetle-wswan-libretro))
+- WonderSwan / WonderSwan Color ([lr-mednafen-wswan](https://github.com/libretro/beetle-wswan-libretro))
 - ZX Spectrum ([lr-fuse](https://github.com/libretro/fuse-libretro))
 
 ### Experimentelle Systeme
 - *Arcade* ([lr-mame2010](https://github.com/libretro/mame2010-libretro))
-- Amiga ([lr-fsuae](https://github.com/libretro/libretro-fsuae))
-- Nintendo DS ([lr-desmume](https://github.com/libretro/desmume))
+- Nintendo DS ([lr-desmume](https://github.com/libretro/desmume) / [DraStic](https://www.raspberrypi.org/forums/viewtopic.php?t=170820&p=1104991))
 - Sega Saturn ([lr-yabause](https://github.com/libretro/yabause))
+
+> Wenn du ein bestimmtes System willst, bitte kommentiere [hier](https://github.com/bite-your-idols/Gamestarter-Pi/issues/35).
 
 ## Mitwirkende
 - Erstellt von [bite-your-idols](https://github.com/bite-your-idols)
@@ -73,11 +77,11 @@ Du kannst [diesen](https://github.com/bite-your-idols/Gamestarter-Pi/raw/master/
 
 ---
 
-![screenshot-advlauncher-mimic](https://github.com/bite-your-idols/Gamestarter-Pi/raw/master/assets/screenshot-gamestarter-advlauncher-mimic.png)
-**Advanced Launcher** Bibliothek mit dem [Mimic Skin](http://kodi.wiki/view/Add-on:mimic)
+![screenshot-gamestarter-settings](https://github.com/bite-your-idols/Gamestarter-Pi/raw/master/assets/screenshot-settings.png)
+**Gamestarter** Einstellungen
 
-![screenshot-advlauncher-mimic](https://github.com/bite-your-idols/Gamestarter-Pi/raw/master/assets/screenshot-settings.png)
-**Addon Settings** screen
+![screenshot-advemulauncher](https://github.com/bite-your-idols/Gamestarter-Pi/raw/master/assets/screenshot-estuary-ael-systems.png)
+**Advanced Emulator Launcher** Bibliothek in **LibreELEC 8**
 
 ![screenshot-advlauncher-mimic](https://github.com/bite-your-idols/Gamestarter-Pi/raw/master/assets/screenshot-gamestarter-advlauncher-mimic.png)
-**Advanced Launcher** library with the [Mimic Skin](http://kodi.wiki/view/Add-on:mimic)
+**Advanced Launcher** Bibliothek mit [Mimic Skin](http://kodi.wiki/view/Add-on:mimic)

--- a/README-ES.md
+++ b/README-ES.md
@@ -1,32 +1,31 @@
 # Gamestarter Pi
-![gamestarter-logo](https://github.com/bite-your-idols/gamestarter/raw/master/assets/gamestarter-logo-dark.jpg)
+![Gamestarter-logo](https://github.com/bite-your-idols/gamestarter/raw/master/assets/gamestarter-logo-dark.jpg)
 
 [English](https://github.com/bite-your-idols/gamestarter/) / Spanish / [German](https://github.com/bite-your-idols/gamestarter/blob/master/README-DE.md)
 
-
-
 ## Retrogaming addon para Kodi en Raspberry Pi
-Si usas la Raspberry Pi 2/3 como media center corriendo Kodi en [LibreELEC](https://libreelec.tv/) o [OpenELEC](http://openelec.tv/), te gusta jugar a juegos retro y quieres lanzarlos como haces con tus pelis o series sin tener que estar cambiado de tarjeta, ni tener arranque dual ni nada de eso, aqui tienes la solución definitiva.
+Si usas la **Raspberry Pi 2/3** como **media center** corriendo **Kodi** en [LibreELEC](https://libreelec.tv/) o [OpenELEC](http://openelec.tv/), te gusta jugar a juegos retro y quieres lanzarlos como haces con tus pelis o series sin tener que estar cambiado de tarjeta, ni tener arranque dual ni nada de eso, **aqui tienes la solución definitiva**.
 
-Con este addon continuarás teniendo tu propia versión de Kodi pero vitaminada con el maravilloso multi-emulador [Retroarch](http://www.libretro.com/) integrado en kodi gracias al addon [AdvacedLauncher](http://forum.kodi.tv/showthread.php?tid=85724)/[Advanced Emulator Launcher](http://forum.kodi.tv/showthread.php?tid=287826). Mira la lista de emuladores más abajo.
+Con este addon continuarás teniendo tu propia versión de Kodi pero vitaminada con el maravilloso multi-emulador [Retroarch](http://www.libretro.com/) integrado en kodi gracias al addon [Advanced Launcher](http://forum.kodi.tv/showthread.php?tid=85724) / [Advanced Emulator Launcher](http://forum.kodi.tv/showthread.php?tid=287826). Mira la lista de emuladores más abajo.
 
 ## Instrucciones de instalación.
-- Descarga la [última versión](https://github.com/bite-your-idols/Gamestarter-Pi/releases/latest) y cópialo en tu Raspberry Pi
-- Ir a **Kodi → Ajustes → Sistema → Add-ons** y activa **Fuentes Desconocidas** (LibreELEC 8)
-- Ir a **Kodi → Add-ons → Install desde archivo zip** y elige el archivo `.zip` descargado
+- Descarga la [última versión](https://github.com/bite-your-idols/Gamestarter-Pi/releases/latest) y cópialo en tu **Raspberry Pi**
+- **[Kodi 17+]** Ir a **Kodi → Ajustes → Sistema → Add-ons** y activa **Fuentes desconocidas**
+- Ir a **Kodi → Add-ons → Instalar desde un archivo .zip** y elige el archivo `.zip` descargado
 
-La primera vez que inicies el addon se realizaran unos ajustes iniciales. Después solo tendrás que copiar tu [roms y bios](https://github.com/libretro/Lakka/wiki/ROMs-and-BIOSes) en la carpeta /storage/emulators/ usando ftp o [samba](http://wiki.openelec.tv/index.php/Accessing_Samba_Shares) y reiniciar.
+La primera vez que inicies el addon se realizaran unos ajustes iniciales. Después solo tendrás que copiar tu [ROMs](https://github.com/libretro/Lakka/wiki/ROMs) y [BIOSes](https://github.com/libretro/Lakka/wiki/BIOSes) en la carpeta `/storage/emulators/` usando [Samba](https://wiki.libreelec.tv/index.php?title=Accessing_LibreELEC#tab=Samba_2FSMB).
 
->Si usas LibreELEC 8, después de la instalación tendras que activar el addon Advanced Emulator Launcher manualmente desde Addons>Mis Addons> Addons de Programas. Es una nueva polític de Kodi 17.
+> Si usas **Kodi 17**, después de la instalación tendras que activar el addon **Advanced Emulator Launcher** manualmente:
+<br>Ir a **Add-ons → Mis add-ons → Add-ons de programas → Advanced Emulator Launcher** y haga clic en **Activar**
 
 ## Instalaciones Opcionales.
-Puesde abrir los ajustas del addon para instalar:
+Puesde abrir los ajustas del addon para instalar.
 - **[EmulationStation](https://github.com/Herdinger/EmulationStation):** el mismo frontend que usan [RetroPie](https://retropie.org.uk/) y [Recalbox](https://recalbox.com/) y algunos temas 
-- **[Internet Archive ROM Launcher](https://github.com/zach-morris/plugin.program.iarl/):**: addon para lanzar juegos desde la "nube" ([ver instrucciones](https://github.com/bite-your-idols/Gamestarter-Pi/issues/31))
-- **RetroArch cores experimentales:** [lr-desmume](https://github.com/libretro/desmume), [lr-mame2010](https://github.com/libretro/mame2010-libretro), [lr-yabause](https://github.com/libretro/yabause)...
+- **[Internet Archive ROM Launcher](https://github.com/zach-morris/plugin.program.iarl/):**: addon para lanzar juegos desde la "nube" (ver [#31](https://github.com/bite-your-idols/Gamestarter-Pi/issues/31))
+- **RetroArch cores experimentales:** [lr-desmume](https://github.com/libretro/desmume), [lr-mame2010](https://github.com/libretro/mame2010-libretro), [lr-yabause](https://github.com/libretro/yabause) ...
 - **[uae4arm-rpi](https://github.com/Chips-fr/uae4arm-rpi):** Emulador de Amiga (ver [#34](https://github.com/bite-your-idols/Gamestarter-Pi/issues/34))
-- **[Libretro PC ports](https://buildbot.libretro.com/assets/cores/):** Cave Story, Doom, Quake, Dinothawr
 - **[DraStic](https://www.raspberrypi.org/forums/viewtopic.php?t=170820&p=1104991):** Emulador en fase beta de Nintendo DS
+- **[Libretro PC ports](https://buildbot.libretro.com/assets/cores/):** Cave Story, Doom, Quake, Dinothawr
 - **Estuary Skin custom:** Con acceso directo en la pantalla de inicio a Advaced Emulator Launcher o Gamestarter (ver [#48](https://github.com/bite-your-idols/Gamestarter-Pi/issues/48))
 
 
@@ -60,16 +59,15 @@ Puesde abrir los ajustas del addon para instalar:
 - Sega Game Gear ([lr-genesis-plus-gx](https://github.com/libretro/Genesis-Plus-GX))
 - ScummVM ([lr-scummvm](https://github.com/libretro/scummvm))
 - Vectrex ([lr-vecx](https://github.com/libretro/libretro-vecx))
-- WondeSwan / WonderSwan Color ([lr-mednafen-wswan](https://github.com/libretro/beetle-wswan-libretro))
+- WonderSwan / WonderSwan Color ([lr-mednafen-wswan](https://github.com/libretro/beetle-wswan-libretro))
 - ZX Spectrum ([lr-fuse](https://github.com/libretro/fuse-libretro))
 
 ### Sistemas Experimentales (en desarrollo)
 - *Arcade* ([lr-mame2010](https://github.com/libretro/mame2010-libretro))
-- Nintendo DS ([lr-desmume](https://github.com/libretro/desmume))
+- Nintendo DS ([lr-desmume](https://github.com/libretro/desmume) / [DraStic](https://www.raspberrypi.org/forums/viewtopic.php?t=170820&p=1104991))
 - Sega Saturn ([lr-yabause](https://github.com/libretro/yabause))
-- Nintendo DS ([DraStic](https://www.raspberrypi.org/forums/viewtopic.php?t=170820&p=1104991))
 
-¿Echas en falta algún sistema? -> coméntalo [aquí](https://github.com/bite-your-idols/Gamestarter-Pi/issues/35).
+> ¿Echas en falta algún sistema? -> coméntalo [aquí](https://github.com/bite-your-idols/Gamestarter-Pi/issues/35).
 
 ## Créditos
 - Created by [bite-your-idols](https://github.com/bite-your-idols)
@@ -80,11 +78,11 @@ Puesde abrir los ajustas del addon para instalar:
 
 ---
 
-![screenshot-advlauncher-mimic](https://github.com/bite-your-idols/Gamestarter-Pi/raw/master/assets/screenshot-estuary-ael-systems.png)
-Ejemplo de la "biblioteca de juegos" con **Advanced Emulator Launcher** en **Estuary Skin**.
-
-![screenshot-advlauncher-mimic](https://github.com/bite-your-idols/Gamestarter-Pi/raw/master/assets/screenshot-settings.png)
+![screenshot-gamestarter-settings](https://github.com/bite-your-idols/Gamestarter-Pi/raw/master/assets/screenshot-settings.png)
 Pantalla de **Ajustes del addon**
 
+![screenshot-advemulauncher](https://github.com/bite-your-idols/Gamestarter-Pi/raw/master/assets/screenshot-estuary-ael-systems.png)
+Ejemplo de la "biblioteca de juegos" con **Advanced Emulator Launcher** en **LibreELEC 8**
+
 ![screenshot-advlauncher-edit](https://github.com/bite-your-idols/Gamestarter-Pi/raw/master/assets/screenshot-gamestarter-advlauncher-mimic.png)
-Ejemplo de la "biblioteca de juegos" de Kodi con [Mimic Skin](http://kodi.wiki/view/Add-on:mimic).
+Ejemplo de la "biblioteca de juegos" con [Mimic Skin](http://kodi.wiki/view/Add-on:mimic)

--- a/README.md
+++ b/README.md
@@ -10,24 +10,23 @@ With this addon you will be able to run **multiple emulators** from [RetroArch](
 
 ## Installation instructions
 - Download the [latest release](https://github.com/bite-your-idols/Gamestarter-Pi/releases/latest) and transfer it to your **Raspberry Pi**
-- Go to **Kodi → Settings → System → Add-ons** and enable **Unknown sources** (LibreELEC 8)
+- **[Kodi 17+]** Go to **Kodi → Settings → System → Add-ons** and enable **Unknown sources**
 - Go to **Kodi → Add-ons → Install from zip file** and select the downloaded `.zip` file
 
 The first time the addon is launched, it will perform a initial setup. You can then copy your [ROMs](https://github.com/libretro/Lakka/wiki/ROMs) and [BIOSes](https://github.com/libretro/Lakka/wiki/BIOSes) to `/storage/emulators/` via [Samba](https://wiki.libreelec.tv/index.php?title=Accessing_LibreELEC#tab=Samba_2FSMB).
 
->If using LibreELEC 8, after installation you have to activate Advanced Emulator Launcher manually in Addons>My Addons> Program Addons. It is a new Kodi 17 policy.
-
+> Since **Kodi 17** you have to activate **Advanced Emulator Launcher** manually:
+<br>Go to **Add-ons → My add-ons → Program add-ons → Advanced Emulator Launcher** and click on **Enable**
 
 ## Optional packages
 You can open the addon settings to install additional features.
 - **[EmulationStation](http://emulationstation.org/):** a nice frontend also used by [RetroPie](https://retropie.org.uk/) and [Recalbox](https://recalbox.com/) and additional themes
 - **[Internet Archive ROM Launcher](https://github.com/zach-morris/plugin.program.iarl/wiki):** addon to launch games from the [Internet Archive](https://archive.org/) (see [#31](https://github.com/bite-your-idols/Gamestarter-Pi/issues/31))
-- **Experimental RetroArch cores:** [lr-desmume](https://github.com/libretro/desmume), [lr-mame2010](https://github.com/libretro/mame2010-libretro), [lr-yabause](https://github.com/libretro/yabause)...
+- **Experimental RetroArch cores:** [lr-desmume](https://github.com/libretro/desmume), [lr-mame2010](https://github.com/libretro/mame2010-libretro), [lr-yabause](https://github.com/libretro/yabause) ...
 - **[uae4arm-rpi](https://github.com/Chips-fr/uae4arm-rpi):** Amiga emulator (see [#34](https://github.com/bite-your-idols/Gamestarter-Pi/issues/34))
+- **[DraStic](https://www.raspberrypi.org/forums/viewtopic.php?t=170820&p=1104991):** Experimental Nintendo DS emulator
 - **[Libretro PC ports](https://buildbot.libretro.com/assets/cores/):** Cave Story, Doom, Quake, Dinothawr
-- **[DraStic](https://www.raspberrypi.org/forums/viewtopic.php?t=170820&p=1104991):** Nintendo DS beta emulator
-- **Custom Estuary Skin:** Including home menu shortcut for Advaced Emulator Launcher or defautl Gamestarter frontend (see [#48](https://github.com/bite-your-idols/Gamestarter-Pi/issues/48))
-
+- **Custom Estuary Skin:** Adds a home menu shortcut for Gamestarter or Advanced Emulator Launcher (see [#48](https://github.com/bite-your-idols/Gamestarter-Pi/issues/48))
 
 ## Included systems
 ### Popular systems
@@ -59,17 +58,15 @@ You can open the addon settings to install additional features.
 - Sega Game Gear ([lr-genesis-plus-gx](https://github.com/libretro/Genesis-Plus-GX))
 - ScummVM ([lr-scummvm](https://github.com/libretro/scummvm))
 - Vectrex ([lr-vecx](https://github.com/libretro/libretro-vecx))
-- WondeSwan / WonderSwan Color ([lr-mednafen-wswan](https://github.com/libretro/beetle-wswan-libretro))
+- WonderSwan / WonderSwan Color ([lr-mednafen-wswan](https://github.com/libretro/beetle-wswan-libretro))
 - ZX Spectrum ([lr-fuse](https://github.com/libretro/fuse-libretro))
 
 ### Experimental systems (WIP)
 - *Arcade* ([lr-mame2010](https://github.com/libretro/mame2010-libretro))
-- Nintendo DS ([lr-desmume](https://github.com/libretro/desmume))
+- Nintendo DS ([lr-desmume](https://github.com/libretro/desmume) / [DraStic](https://www.raspberrypi.org/forums/viewtopic.php?t=170820&p=1104991))
 - Sega Saturn ([lr-yabause](https://github.com/libretro/yabause))
-- Nintendo DS ([DraStic](https://www.raspberrypi.org/forums/viewtopic.php?t=170820&p=1104991))
 
->Missing a system? -> post [here](https://github.com/bite-your-idols/Gamestarter-Pi/issues/35).
-
+> If you want a specific system to be included, please comment [here](https://github.com/bite-your-idols/Gamestarter-Pi/issues/35).
 
 ## Credits
 - Created by [bite-your-idols](https://github.com/bite-your-idols)
@@ -80,11 +77,11 @@ You can open the addon settings to install additional features.
 
 ---
 
-![screenshot-advlauncher-mimic](https://github.com/bite-your-idols/Gamestarter-Pi/raw/master/assets/screenshot-estuary-ael-systems.png)
-**Advanced Emulator Launcher** library with default **Estuary Skin** in LibreELEC 8
+![screenshot-gamestarter-settings](https://github.com/bite-your-idols/Gamestarter-Pi/raw/master/assets/screenshot-settings.png)
+**Gamestarter** settings screen
 
-![screenshot-advlauncher-mimic](https://github.com/bite-your-idols/Gamestarter-Pi/raw/master/assets/screenshot-settings.png)
-**Addon Settings** screen
+![screenshot-advemulauncher](https://github.com/bite-your-idols/Gamestarter-Pi/raw/master/assets/screenshot-estuary-ael-systems.png)
+**Advanced Emulator Launcher** library in **LibreELEC 8**
 
 ![screenshot-advlauncher-mimic](https://github.com/bite-your-idols/Gamestarter-Pi/raw/master/assets/screenshot-gamestarter-advlauncher-mimic.png)
-**Advanced Launcher** library with the [Mimic Skin](http://kodi.wiki/view/Add-on:mimic)
+**Advanced Launcher** library with [Mimic Skin](http://kodi.wiki/view/Add-on:mimic)


### PR DESCRIPTION
Created a new pull request so we can have everything organized.

I saw you changes and made some small corrections. This time I also changed some of the spanish ReadMe (sorry :stuck_out_tongue_closed_eyes: ) but you're free to change everything you want.

While editing I noticed that [lr-fsuae](https://github.com/libretro/libretro-fsuae) is now gone. I'm not currently using Gamestarter, but what happend to it?