### PR TITLE
Show Gamestarter under game add-ons (Kodi 18)

### DIFF
--- a/script.gamestarter/addon.xml
+++ b/script.gamestarter/addon.xml
@@ -4,7 +4,7 @@
     <import addon="xbmc.python" version="2.1.0"/>
   </requires>
   <extension point="xbmc.python.pluginsource" library="default.py">
-		<provides>executable</provides>
+		<provides>executable game</provides>
 	</extension>
   <extension point="xbmc.addon.metadata">
     <summary lang="es">Retrogaming addon para Raspberry Pi</summary>


### PR DESCRIPTION
This adds "game" as a content type so that Gamestarter will appear in Game add-ons. This only affects Kodi 18 and is fully backwards compatible.

![screenshot000](https://cloud.githubusercontent.com/assets/531482/26756867/c1d86c3a-4860-11e7-94f9-098e33e85381.png)

Note, to see game add-ons in Kodi you must enter the secret cheat code.